### PR TITLE
Add ES credentials and config to generate and send messages via hermes

### DIFF
--- a/overlays/prod/rucio/helm-rucio-daemons.yaml
+++ b/overlays/prod/rucio/helm-rucio-daemons.yaml
@@ -103,6 +103,20 @@ type: Opaque
 data:
   component.json: "e30="
 ---
+# Source: rucio-daemons/templates/hermes.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: usdf-rucio-daemons.config.hermes
+  labels:
+    app: rucio-daemons-hermes
+    chart: "rucio-daemons-32.0.2"
+    release: "usdf"
+    heritage: "Helm"
+type: Opaque
+data:
+  component.json: "e30="
+---
 # Source: rucio-daemons/templates/judge.yaml
 apiVersion: v1
 kind: Secret
@@ -213,7 +227,7 @@ metadata:
     heritage: "Helm"
 type: Opaque
 data:
-  common.json: "ewogICJhdXRvbWF0aXgiOiB7CiAgICAiYWNjb3VudCI6ICJhdXRvbWF0aXgiLAogICAgImRhdGFzZXRfbGlmZXRpbWUiOiAxODAwMCwKICAgICJkYXRhc2V0X3BhdHRlcm4iOiAiZGlkX3ByZWZpeC9kYXRlL3V1aWQiLAogICAgImRpZF9wcmVmaXgiOiAiYXV0b21hdGl4IiwKICAgICJmaWxlX3BhdHRlcm4iOiAiZHNuL3V1aWQiLAogICAgInJzZXMiOiAiSU4yUDNfQlVUTEVSX0RJU0ssIExBTkNTX0JVVExFUl9ESVNLLCBSQUxfQlVUTEVSX0RJU0ssIFJBTF9EQVRBX0RJU0ssIElOMlAzX0RBVEFfRElTSywgTEFOQ1NfREFUQV9ESVNLIiwKICAgICJzY29wZSI6ICJ1c2VyLmF1dG9tYXRpeCIsCiAgICAic2VwYXJhdG9yIjogIi8iLAogICAgInNldF9tZXRhZGF0YSI6ICJUcnVlIgogIH0sCiAgImNsaWVudCI6IHsKICAgICJhY2NvdW50IjogImF1dG9tYXRpeCIsCiAgICAiYXV0aF9ob3N0IjogImh0dHBzOi8vcnViaW4tcnVjaW8uc2xhYy5zdGFuZm9yZC5lZHU6ODQ0MyIsCiAgICAiYXV0aF90eXBlIjogIng1MDlfcHJveHkiLAogICAgImNhX2NlcnQiOiAiL29wdC9jZXJ0cyIsCiAgICAiY2xpZW50X3g1MDlfcHJveHkiOiAiL29wdC9wcm94eS94NTA5dXAiLAogICAgInByb3RvY29sX3N0YXRfcmV0cmllcyI6IDYsCiAgICAicmVxdWVzdF9yZXRyaWVzIjogNiwKICAgICJydWNpb19ob3N0IjogImh0dHBzOi8vcnViaW4tcnVjaW8uc2xhYy5zdGFuZm9yZC5lZHU6ODQ0MyIKICB9LAogICJjb252ZXlvciI6IHsKICAgICJjYWNlcnQiOiAiL29wdC9jZXJ0cy9jYS5wZW0iLAogICAgImZ0c2hvc3RzIjogImh0dHBzOi8vZnRzLWV2YWwwMS5zbGFjLnN0YW5mb3JkLmVkdTo4NDQ2LGh0dHBzOi8vbGNnZnRzMy5ncmlkcHAucmwuYWMudWs6ODQ0NiIsCiAgICAic2NoZW1lIjogInNybSxnc2lmdHAscm9vdCxodHRwLGh0dHBzIiwKICAgICJ0cmFuc2ZlcnRvb2wiOiAiZnRzMyIsCiAgICAidXNlcmNlcnQiOiAiL29wdC9wcm94eS94NTA5dXAiCiAgfSwKICAiaGVybWVzIjogewogICAgInNlcnZpY2VzX2xpc3QiOiAia2Fma2EiCiAgfSwKICAibWVzc2FnaW5nLWhlcm1lcy1rYWZrYSI6IHsKICAgICJicm9rZXIiOiAiMTM0Ljc5LjIzLjIyMTo5MDk0LDEzNC43OS4yMy4yMjI6OTA5NCwxMzQuNzkuMjMuMjIzOjkwOTQiLAogICAgIm1lc3NhZ2VfZmlsdGVyIjogInJ1Y2lvLmRhZW1vbnMuaGVybWVzLmthZmthLmZpbHRlcnMuZmlsdGVyZWRfbGlzdCIsCiAgICAibm9uc3NsX3BvcnQiOiA5MDkyLAogICAgInBvcnQiOiA5MDkyLAogICAgInRvcGljX2xpc3QiOiAiVVNERl9TVFNfRElTSyxGUkRGX1NUU19ESVNLIiwKICAgICJ1c2Vfc3NsIjogZmFsc2UKICB9LAogICJtb25pdG9yIjogewogICAgImVuYWJsZV9tZXRyaWNzIjogIlRydWUiCiAgfSwKICAicG9saWN5IjogewogICAgInBhY2thZ2UiOiAicnViaW4iCiAgfSwKICAidHJhbnNmZXJzIjogewogICAgIm11bHRpaG9wX3JzZV9leHByZXNzaW9uIjogIiIKICB9LAogICJ0cmFuc21vZ3JpZmllciI6IHsKICAgICJtYXhkaWRzIjogNDAwMDAKICB9Cn0="
+  common.json: "ewogICJhdXRvbWF0aXgiOiB7CiAgICAiYWNjb3VudCI6ICJhdXRvbWF0aXgiLAogICAgImRhdGFzZXRfbGlmZXRpbWUiOiAxODAwMCwKICAgICJkYXRhc2V0X3BhdHRlcm4iOiAiZGlkX3ByZWZpeC9kYXRlL3V1aWQiLAogICAgImRpZF9wcmVmaXgiOiAiYXV0b21hdGl4IiwKICAgICJmaWxlX3BhdHRlcm4iOiAiZHNuL3V1aWQiLAogICAgInJzZXMiOiAiSU4yUDNfQlVUTEVSX0RJU0ssIExBTkNTX0JVVExFUl9ESVNLLCBSQUxfQlVUTEVSX0RJU0ssIFJBTF9EQVRBX0RJU0ssIElOMlAzX0RBVEFfRElTSywgTEFOQ1NfREFUQV9ESVNLIiwKICAgICJzY29wZSI6ICJ1c2VyLmF1dG9tYXRpeCIsCiAgICAic2VwYXJhdG9yIjogIi8iLAogICAgInNldF9tZXRhZGF0YSI6ICJUcnVlIgogIH0sCiAgImNsaWVudCI6IHsKICAgICJhY2NvdW50IjogImF1dG9tYXRpeCIsCiAgICAiYXV0aF9ob3N0IjogImh0dHBzOi8vcnViaW4tcnVjaW8uc2xhYy5zdGFuZm9yZC5lZHU6ODQ0MyIsCiAgICAiYXV0aF90eXBlIjogIng1MDlfcHJveHkiLAogICAgImNhX2NlcnQiOiAiL29wdC9jZXJ0cyIsCiAgICAiY2xpZW50X3g1MDlfcHJveHkiOiAiL29wdC9wcm94eS94NTA5dXAiLAogICAgInByb3RvY29sX3N0YXRfcmV0cmllcyI6IDYsCiAgICAicmVxdWVzdF9yZXRyaWVzIjogNiwKICAgICJydWNpb19ob3N0IjogImh0dHBzOi8vcnViaW4tcnVjaW8uc2xhYy5zdGFuZm9yZC5lZHU6ODQ0MyIKICB9LAogICJjb252ZXlvciI6IHsKICAgICJjYWNlcnQiOiAiL29wdC9jZXJ0cy9jYS5wZW0iLAogICAgImZ0c2hvc3RzIjogImh0dHBzOi8vZnRzLWV2YWwwMS5zbGFjLnN0YW5mb3JkLmVkdTo4NDQ2LGh0dHBzOi8vbGNnZnRzMy5ncmlkcHAucmwuYWMudWs6ODQ0NiIsCiAgICAic2NoZW1lIjogInNybSxnc2lmdHAscm9vdCxodHRwLGh0dHBzIiwKICAgICJ0cmFuc2ZlcnRvb2wiOiAiZnRzMyIsCiAgICAidXNlcmNlcnQiOiAiL29wdC9wcm94eS94NTA5dXAiCiAgfSwKICAiaGVybWVzIjogewogICAgImVsYXN0aWNfZW5kcG9pbnQiOiAiaHR0cDovL2VsYXN0aWNzZWFyY2gtZWNrLWVsYXN0aWNzZWFyY2gtZXMtd29ya2VyLmVsYXN0aWMtc3lzdGVtLnN2Yy5jbHVzdGVyLmxvY2FsOjkyMDAvcnVjaW9fZXZlbnRzL19idWxrIiwKICAgICJzZXJ2aWNlc19saXN0IjogImthZmthLCBlbGFzdGljIgogIH0sCiAgIm1lc3NhZ2luZy1oZXJtZXMta2Fma2EiOiB7CiAgICAiYnJva2VyIjogIjEzNC43OS4yMy4yMjE6OTA5NCwxMzQuNzkuMjMuMjIyOjkwOTQsMTM0Ljc5LjIzLjIyMzo5MDk0IiwKICAgICJtZXNzYWdlX2ZpbHRlciI6ICJydWNpby5kYWVtb25zLmhlcm1lcy5rYWZrYS5maWx0ZXJzLmZpbHRlcmVkX2xpc3QiLAogICAgIm5vbnNzbF9wb3J0IjogOTA5MiwKICAgICJwb3J0IjogOTA5MiwKICAgICJ0b3BpY19saXN0IjogIlVTREZfU1RTX0RJU0ssRlJERl9TVFNfRElTSyIsCiAgICAidXNlX3NzbCI6IGZhbHNlCiAgfSwKICAibW9uaXRvciI6IHsKICAgICJlbmFibGVfbWV0cmljcyI6ICJUcnVlIgogIH0sCiAgInBvbGljeSI6IHsKICAgICJwYWNrYWdlIjogInJ1YmluIgogIH0sCiAgInRyYW5zZmVycyI6IHsKICAgICJtdWx0aWhvcF9yc2VfZXhwcmVzc2lvbiI6ICIiCiAgfSwKICAidHJhbnNtb2dyaWZpZXIiOiB7CiAgICAibWF4ZGlkcyI6IDQwMDAwCiAgfQp9"
 ---
 # Source: rucio-daemons/templates/transmogrifier.yaml
 apiVersion: v1
@@ -607,7 +621,7 @@ spec:
         release: usdf
         rucio-daemon: automatix
       annotations:
-        checksum/config: 239829666a2328dd380f8e7f733d82c56a1d95c7
+        checksum/config: 32f0b60f84ffdda08d432c47de4eb3dda9ee227b
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -720,7 +734,7 @@ spec:
         release: usdf
         rucio-daemon: conveyor-finisher
       annotations:
-        checksum/config: 239829666a2328dd380f8e7f733d82c56a1d95c7
+        checksum/config: 32f0b60f84ffdda08d432c47de4eb3dda9ee227b
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -826,7 +840,7 @@ spec:
         release: usdf
         rucio-daemon: conveyor-poller
       annotations:
-        checksum/config: 239829666a2328dd380f8e7f733d82c56a1d95c7
+        checksum/config: 32f0b60f84ffdda08d432c47de4eb3dda9ee227b
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -932,7 +946,7 @@ spec:
         release: usdf
         rucio-daemon: conveyor-submitter
       annotations:
-        checksum/config: 239829666a2328dd380f8e7f733d82c56a1d95c7
+        checksum/config: 32f0b60f84ffdda08d432c47de4eb3dda9ee227b
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1007,6 +1021,114 @@ spec:
               cpu: 700m
               memory: 600Mi
 ---
+# Source: rucio-daemons/templates/hermes.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: usdf-hermes
+  labels:
+    app: rucio-daemons-hermes
+    app-group: rucio-daemons
+    chart: rucio-daemons-32.0.2
+    release: usdf
+    heritage: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rucio-daemons-hermes
+      release: usdf
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app: rucio-daemons-hermes
+        app-group: rucio-daemons
+        release: usdf
+        rucio-daemon: hermes
+      annotations:
+        checksum/config: 32f0b60f84ffdda08d432c47de4eb3dda9ee227b
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+    spec:
+      volumes:
+        - name: config-common
+          secret:
+            secretName: usdf-rucio-daemons.config.common
+        - name: config-component
+          secret:
+            secretName: usdf-rucio-daemons.config.hermes
+
+        - name: rucio-automatix-input-file
+          secret:
+            secretName: usdf-rucio-automatix-input-file
+        - name: hermeskafka-constants
+          secret:
+            secretName: usdf-hermeskafka-constants
+        - name: policy-package
+          secret:
+            secretName: usdf-policy-package
+      containers:
+        - name: rucio-daemons
+          image: "rucio/rucio-daemons:release-33.5.0"
+          imagePullPolicy: Always
+          volumeMounts:
+
+            - name: config-common
+              mountPath: /opt/rucio/etc/conf.d/10_common.json
+              subPath: common.json
+            - name: config-component
+              mountPath: /opt/rucio/etc/conf.d/20_component.json
+              subPath: component.json
+            - name: rucio-automatix-input-file
+              mountPath: /opt/rucio/etc/automatix.json
+              subPath: "automatix.json"
+            - name: hermeskafka-constants
+              mountPath: /usr/local/lib/python3.9/site-packages/rucio/common/constants.py
+              subPath: "constants.py"
+            - name: policy-package
+              mountPath: /opt/rucio/permissions/rubin
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: RUCIO_OVERRIDE_CONFIGS
+              value: "/opt/rucio/etc/conf.d/"
+            - name: RUCIO_DAEMON
+              value: "hermes"
+            - name: RUCIO_DAEMON_ARGS
+              value: " --threads 1  --bulk 100"
+            - name: PYTHONPATH
+              value: /opt/rucio/permissions
+            - name: RUCIO_CFG_DATABASE_DEFAULT
+              valueFrom:
+                secretKeyRef:
+                  key: db-conn-str.txt
+                  name: usdf-db-conn-str
+            - name: RUCIO_CFG_HERMES_ELASTIC_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: USERNAME
+                  name: usdf-elasticsearch
+            - name: RUCIO_CFG_HERMES_ELASTIC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: PASSWORD
+                  name: usdf-elasticsearch
+          resources:
+            limits:
+              cpu: 700m
+              memory: 600Mi
+            requests:
+              cpu: 700m
+              memory: 600Mi
+---
 # Source: rucio-daemons/templates/judge.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -1038,7 +1160,7 @@ spec:
         release: usdf
         rucio-daemon: judge-cleaner
       annotations:
-        checksum/config: 239829666a2328dd380f8e7f733d82c56a1d95c7
+        checksum/config: 32f0b60f84ffdda08d432c47de4eb3dda9ee227b
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1144,7 +1266,7 @@ spec:
         release: usdf
         rucio-daemon: judge-evaluator
       annotations:
-        checksum/config: 239829666a2328dd380f8e7f733d82c56a1d95c7
+        checksum/config: 32f0b60f84ffdda08d432c47de4eb3dda9ee227b
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1250,7 +1372,7 @@ spec:
         release: usdf
         rucio-daemon: judge-injector
       annotations:
-        checksum/config: 239829666a2328dd380f8e7f733d82c56a1d95c7
+        checksum/config: 32f0b60f84ffdda08d432c47de4eb3dda9ee227b
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1356,7 +1478,7 @@ spec:
         release: usdf
         rucio-daemon: judge-repairer
       annotations:
-        checksum/config: 239829666a2328dd380f8e7f733d82c56a1d95c7
+        checksum/config: 32f0b60f84ffdda08d432c47de4eb3dda9ee227b
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1462,7 +1584,7 @@ spec:
         release: usdf
         rucio-daemon: minos
       annotations:
-        checksum/config: 239829666a2328dd380f8e7f733d82c56a1d95c7
+        checksum/config: 32f0b60f84ffdda08d432c47de4eb3dda9ee227b
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1568,7 +1690,7 @@ spec:
         release: usdf
         rucio-daemon: necromancer
       annotations:
-        checksum/config: 239829666a2328dd380f8e7f733d82c56a1d95c7
+        checksum/config: 32f0b60f84ffdda08d432c47de4eb3dda9ee227b
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1674,7 +1796,7 @@ spec:
         release: usdf
         rucio-daemon: reaper
       annotations:
-        checksum/config: 239829666a2328dd380f8e7f733d82c56a1d95c7
+        checksum/config: 32f0b60f84ffdda08d432c47de4eb3dda9ee227b
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1786,7 +1908,7 @@ spec:
         release: usdf
         rucio-daemon: transmogrifier
       annotations:
-        checksum/config: 239829666a2328dd380f8e7f733d82c56a1d95c7
+        checksum/config: 32f0b60f84ffdda08d432c47de4eb3dda9ee227b
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1892,7 +2014,7 @@ spec:
         release: usdf
         rucio-daemon: undertaker
       annotations:
-        checksum/config: 239829666a2328dd380f8e7f733d82c56a1d95c7
+        checksum/config: 32f0b60f84ffdda08d432c47de4eb3dda9ee227b
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:

--- a/overlays/prod/rucio/values-rucio-daemons.yaml
+++ b/overlays/prod/rucio/values-rucio-daemons.yaml
@@ -8,23 +8,23 @@ abacusCollectionReplicaCount: 1
 abacusRseCount: 1
 automatixCount: 1
 cacheConsumerCount: 0
-conveyorTransferSubmitterCount: 1 
+conveyorTransferSubmitterCount: 1
 conveyorPollerCount: 1
-conveyorFinisherCount: 1 
+conveyorFinisherCount: 1
 conveyorReceiverCount: 0
 conveyorStagerCount: 0
 conveyorThrottlerCount: 0
 conveyorPreparerCount: 0
 darkReaperCount: 0
-hermesCount: 0
-judgeCleanerCount:  1
-judgeEvaluatorCount: 1 
+hermesCount: 1
+judgeCleanerCount: 1
+judgeEvaluatorCount: 1
 judgeInjectorCount: 1
 judgeRepairerCount: 1
 oauthManagerCount: 0
 undertakerCount: 1
-reaperCount: 1 
-transmogrifierCount: 1 
+reaperCount: 1
+transmogrifierCount: 1
 tracerKronosCount: 0
 minosCount: 1
 minosTemporaryExpirationCount: 0
@@ -47,8 +47,8 @@ use_deprecated_implicit_secrets: true
 podLabels: {}
 # Enable Prometheus scraping of metrics
 podAnnotations:
-    prometheus.io/port: "8080"
-    prometheus.io/scrape: "true"
+  prometheus.io/port: "8080"
+  prometheus.io/scrape: "true"
 
 minReadySeconds: 5
 
@@ -74,13 +74,13 @@ abacusAccount:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 abacusCollectionReplica:
   threads: 1
@@ -93,13 +93,13 @@ abacusCollectionReplica:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 abacusRse:
   fillHistoryTable: 0
@@ -113,13 +113,13 @@ abacusRse:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 automatix:
   sleep_time: 300
@@ -134,13 +134,13 @@ automatix:
       memory: "1200Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 cacheConsumer:
   threads: 1
@@ -153,13 +153,13 @@ cacheConsumer:
       memory: "400Mi"
       cpu: "100m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 conveyorTransferSubmitter:
   threads: 1
@@ -175,13 +175,13 @@ conveyorTransferSubmitter:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 conveyorPoller:
   threads: 1
@@ -195,13 +195,13 @@ conveyorPoller:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 conveyorFinisher:
   threads: 1
@@ -215,13 +215,13 @@ conveyorFinisher:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 conveyorReceiver:
   threads: 1
@@ -234,13 +234,13 @@ conveyorReceiver:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 conveyorThrottler:
   threads: 1
@@ -253,13 +253,13 @@ conveyorThrottler:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 conveyorPreparer:
   threads: 1
@@ -272,13 +272,13 @@ conveyorPreparer:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 darkReaper:
   workers: 1
@@ -296,13 +296,13 @@ darkReaper:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 hermes:
   threads: 1
@@ -318,13 +318,23 @@ hermes:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
+  - name: RUCIO_CFG_HERMES_ELASTIC_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: usdf-elasticsearch
+        key: USERNAME
+  - name: RUCIO_CFG_HERMES_ELASTIC_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: usdf-elasticsearch
+        key: PASSWORD
 
 judgeCleaner:
   threads: 1
@@ -337,13 +347,13 @@ judgeCleaner:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 judgeEvaluator:
   threads: 1
@@ -356,13 +366,13 @@ judgeEvaluator:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 judgeInjector:
   threads: 1
@@ -375,13 +385,13 @@ judgeInjector:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 judgeRepairer:
   threads: 1
@@ -394,13 +404,13 @@ judgeRepairer:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 oauthManager:
   threads: 1
@@ -413,13 +423,13 @@ oauthManager:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 undertaker:
   threads: 1
@@ -432,13 +442,13 @@ undertaker:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 reaper:
   greedy: 0
@@ -454,13 +464,13 @@ reaper:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 transmogrifier:
   threads: 1
@@ -473,13 +483,13 @@ transmogrifier:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 tracerKronos:
   threads: 1
@@ -492,13 +502,13 @@ tracerKronos:
       memory: "600Mi"
       cpu: "700m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 minos:
   threads: 1
@@ -511,13 +521,13 @@ minos:
       memory: "400Mi"
       cpu: "100m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 minosTemporaryExpiration:
   threads: 1
@@ -530,13 +540,13 @@ minosTemporaryExpiration:
       memory: "400Mi"
       cpu: "100m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 necromancer:
   podAnnotations: {}
@@ -548,13 +558,13 @@ necromancer:
       memory: "400Mi"
       cpu: "100m"
   additionalEnvs:
-    - name: PYTHONPATH
-      value: /opt/rucio/permissions
-    - name: RUCIO_CFG_DATABASE_DEFAULT
-      valueFrom:
-        secretKeyRef:
-          name: usdf-db-conn-str
-          key: db-conn-str.txt
+  - name: PYTHONPATH
+    value: /opt/rucio/permissions
+  - name: RUCIO_CFG_DATABASE_DEFAULT
+    valueFrom:
+      secretKeyRef:
+        name: usdf-db-conn-str
+        key: db-conn-str.txt
 
 ftsRenewal:
   enabled: 1
@@ -564,16 +574,16 @@ ftsRenewal:
     tag: latest
     pullPolicy: Always
   servers: "https://fts-eval01.slac.stanford.edu:8446,https://lcgfts3.gridpp.rl.ac.uk:8446"
-  script: 'default'  # one of: 'default', 'atlas', 'dteam', 'multi_vo', 'tutorial', 'escape'. The associated scripts can be found here: https://github.com/rucio/containers/tree/master/fts-cron
+  script: 'default' # one of: 'default', 'atlas', 'dteam', 'multi_vo', 'tutorial', 'escape'. The associated scripts can be found here: https://github.com/rucio/containers/tree/master/fts-cron
   vos:
-    - vo: "lsst"
-      voms: "lsst:/lsst/Role=ddmopr"
+  - vo: "lsst"
+    voms: "lsst:/lsst/Role=ddmopr"
   secretMounts:
-    - secretName: voms-servers-file
-      mountPath: /etc/vomses/vomses
-      subPath: vomses
-    - secretName: lsst-vomsdir
-      mountPath: /etc/grid-security/vomsdir
+  - secretName: voms-servers-file
+    mountPath: /etc/vomses/vomses
+    subPath: vomses
+  - secretName: lsst-vomsdir
+    mountPath: /etc/grid-security/vomsdir
     #- secretName: fts-cert
     #  mountPath: /opt/rucio/certs/usercert.pem
     #  subPath: usercert.pem
@@ -584,12 +594,12 @@ ftsRenewal:
     #   mountPath: /opt/rucio/certs/long.proxy
     #   subPath: long.proxy
   additionalEnvs:
-    #- name: RUCIO_FTS_SECRETS
-    #  value: fnal-rucio-x509up
-    - name: USERCERT_NAME
-      value: "usercert.pem"
-    - name: USERKEY_NAME
-      value: "new_userkey.pem"
+  #- name: RUCIO_FTS_SECRETS
+  #  value: fnal-rucio-x509up
+  - name: USERCERT_NAME
+    value: "usercert.pem"
+  - name: USERKEY_NAME
+    value: "new_userkey.pem"
     # - name: RUCIO_LONG_PROXY
     #   value: long.proxy
     # - name: GRID_PASSPHRASE
@@ -614,14 +624,14 @@ automaticRestart:
   schedule: "0 0 * * *"
 
 secretMounts:
-  - secretName: rucio-automatix-input-file
-    mountPath: /opt/rucio/etc/automatix.json
-    subPath: automatix.json
-  - secretName: hermeskafka-constants
-    mountPath: /usr/local/lib/python3.9/site-packages/rucio/common/constants.py
-    subPath: constants.py
-  - secretName: policy-package
-    mountPath: /opt/rucio/permissions/rubin
+- secretName: rucio-automatix-input-file
+  mountPath: /opt/rucio/etc/automatix.json
+  subPath: automatix.json
+- secretName: hermeskafka-constants
+  mountPath: /usr/local/lib/python3.9/site-packages/rucio/common/constants.py
+  subPath: constants.py
+- secretName: policy-package
+  mountPath: /opt/rucio/permissions/rubin
 
 ## common config values used to configure the Rucio daemons
 config:
@@ -637,34 +647,34 @@ config:
     # special_accounts: "panda, tier0"
 
   # common:
-    ## config.common.logdir: the default directoy to write logs to (default: "/var/log/rucio")
-    # logdir: "/var/log/rucio"
-    ## config.common.logdir: the max loglevel (default: "DEBUG")
-    # loglevel: "DEBUG"
-    ## config.common.mailtemplatedir: directory containing the mail templates (default: "/opt/rucio/etc/mail_templates")
-    # mailtemplatedir: "/opt/rucio/etc/mail_templates"
+  ## config.common.logdir: the default directoy to write logs to (default: "/var/log/rucio")
+  # logdir: "/var/log/rucio"
+  ## config.common.logdir: the max loglevel (default: "DEBUG")
+  # loglevel: "DEBUG"
+  ## config.common.mailtemplatedir: directory containing the mail templates (default: "/opt/rucio/etc/mail_templates")
+  # mailtemplatedir: "/opt/rucio/etc/mail_templates"
 
   # database:
-    ## config.database.default: the connection string for the database (default: "sqlite:////tmp/rucio.db")
-    # default: "sqlite:////tmp/rucio.db"
-    ## config.database.schema: the schema used in the DB. only necessary when using Oracle.
-    # schema: ""
-    ## config.database.pool_reset_on_return: set the “reset on return” behavior of the pool (default: "rollback")
-    # pool_reset_on_return: "rollback"
-    ## config.database.echo: flag to control the logging of all statements to stdout (default: "0")
-    # echo: "0"
-    ## config.database.po0l_recycle: this setting causes the pool to recycle connections after the given number of seconds has passed (default: "600")
-    # pool_recycle: "600"
-    ## config.database.pool_size: the number of connections to keep open inside the connection pool
-    # pool_size: ""
-    ## config.database.pool_timeout: number of seconds to wait before giving up on getting a connection from the pool
-    # pool_timeout: ""
-    ## config.database.maxoverflow: the number of connections to allow in connection pool "overflow"
-    # max_overflow: ""
-    ## config.database.powuseraccount: user used to check the DB
-    # powuseraccount: ""
-    ## config.database.powuseraccount: password for user used to check the DB
-    # powuserpassword: ""
+  ## config.database.default: the connection string for the database (default: "sqlite:////tmp/rucio.db")
+  # default: "sqlite:////tmp/rucio.db"
+  ## config.database.schema: the schema used in the DB. only necessary when using Oracle.
+  # schema: ""
+  ## config.database.pool_reset_on_return: set the “reset on return” behavior of the pool (default: "rollback")
+  # pool_reset_on_return: "rollback"
+  ## config.database.echo: flag to control the logging of all statements to stdout (default: "0")
+  # echo: "0"
+  ## config.database.po0l_recycle: this setting causes the pool to recycle connections after the given number of seconds has passed (default: "600")
+  # pool_recycle: "600"
+  ## config.database.pool_size: the number of connections to keep open inside the connection pool
+  # pool_size: ""
+  ## config.database.pool_timeout: number of seconds to wait before giving up on getting a connection from the pool
+  # pool_timeout: ""
+  ## config.database.maxoverflow: the number of connections to allow in connection pool "overflow"
+  # max_overflow: ""
+  ## config.database.powuseraccount: user used to check the DB
+  # powuseraccount: ""
+  ## config.database.powuseraccount: password for user used to check the DB
+  # powuserpassword: ""
 
   monitor:
     ## Turn on the Prometheus server for scraping of metrics (Default port 8080)
@@ -702,7 +712,7 @@ config:
     separator: "/"
     file_pattern: "dsn/uuid"
     dataset_pattern: "did_prefix/date/uuid"
-    
+
 
   conveyor:
     scheme: "srm,gsiftp,root,http,https"
@@ -721,29 +731,30 @@ config:
     # ftsmonhosts: ""
 
   # messaging-fts3:
-    # port: "61123"
-    # ssl_key_file: "/etc/grid-security/hostkey.pem"
-    # ssl_cert_file: "/etc/grid-security/hostcert.pem"
-    # destination: "/topic/transfer.fts_monitoring_queue_state"
-    # brokers: "dashb-test-mb.cern.ch"
-    # voname: "atlas"
+  # port: "61123"
+  # ssl_key_file: "/etc/grid-security/hostkey.pem"
+  # ssl_cert_file: "/etc/grid-security/hostcert.pem"
+  # destination: "/topic/transfer.fts_monitoring_queue_state"
+  # brokers: "dashb-test-mb.cern.ch"
+  # voname: "atlas"
 
   # messaging-hermes:
-    # username: ""
-    # password: ""
-    # port: "61023"
-    # nonssl_port: ""
-    # use_ssl: ""
-    # ssl_key_file: "/etc/grid-security/hostkey.pem"
-    # ssl_cert_file: "/etc/grid-security/hostcert.pem"
-    # destination: "/topic/rucio.events"
-    # brokers: "atlas-test-mb.cern.ch"
-    # voname: "atlas"
-    # email_from: "Rucio <atlas-adc-ddm-support@cern.ch"
-    # email_test: ""
+  # username: ""
+  # password: ""
+  # port: "61023"
+  # nonssl_port: ""
+  # use_ssl: ""
+  # ssl_key_file: "/etc/grid-security/hostkey.pem"
+  # ssl_cert_file: "/etc/grid-security/hostcert.pem"
+  # destination: "/topic/rucio.events"
+  # brokers: "atlas-test-mb.cern.ch"
+  # voname: "atlas"
+  # email_from: "Rucio <atlas-adc-ddm-support@cern.ch"
+  # email_test: ""
 
   hermes:
-    services_list: kafka
+    services_list: kafka, elastic
+    elastic_endpoint: "http://elasticsearch-eck-elasticsearch-es-worker.elastic-system.svc.cluster.local:9200/rucio_events/_bulk"
 
   messaging-hermes-kafka:
     port: 9092
@@ -754,35 +765,35 @@ config:
     topic_list: USDF_STS_DISK,FRDF_STS_DISK
 
   # tracer-kronos:
-    # brokers: "atlas-test-mb.cern.ch"
-    # port: "61013"
-    # ssl_key_file: "/etc/grid-security/hostkey.pem"
-    # ssl_cert_file: "/etc/grid-security/hostcert.pem"
-    # queue: "/queue/Consumer.kronos.rucio.tracer"
-    # prefetch_size: "10"
-    # chunksize: "10"
-    # subscription_id: "rucio-tracer-listener"
-    # use_ssl: "False"
-    # reconnect_attempts: "100"
-    # excluded_usrdns: ""
-    # username: ""
-    # password: ""
-    # dataset_wait: 60
+  # brokers: "atlas-test-mb.cern.ch"
+  # port: "61013"
+  # ssl_key_file: "/etc/grid-security/hostkey.pem"
+  # ssl_cert_file: "/etc/grid-security/hostcert.pem"
+  # queue: "/queue/Consumer.kronos.rucio.tracer"
+  # prefetch_size: "10"
+  # chunksize: "10"
+  # subscription_id: "rucio-tracer-listener"
+  # use_ssl: "False"
+  # reconnect_attempts: "100"
+  # excluded_usrdns: ""
+  # username: ""
+  # password: ""
+  # dataset_wait: 60
 
   transmogrifier:
     maxdids: 40000
 
   # messaging-cache:
-    # port: "61123"
-    # ssl_key_file: "/etc/grid-security/hostkey.pem"
-    # ssl_cert_file: "/etc/grid-security/hostcert.pem"
-    # destination: "/topic/rucio.cache"
-    # brokers: "dashb-test-mb.cern.ch"
-    # voname: "atlas"
-    # account: "ddm"
+  # port: "61123"
+  # ssl_key_file: "/etc/grid-security/hostkey.pem"
+  # ssl_cert_file: "/etc/grid-security/hostcert.pem"
+  # destination: "/topic/rucio.cache"
+  # brokers: "dashb-test-mb.cern.ch"
+  # voname: "atlas"
+  # account: "ddm"
 
   # credentials:
-    # gcs: "/opt/rucio/etc/google-cloud-storage-test.json"
-    # signature_lifetime: "3600"
+  # gcs: "/opt/rucio/etc/google-cloud-storage-test.json"
+  # signature_lifetime: "3600"
 
 


### PR DESCRIPTION
I have added the elasticsearch credentials to the rucio name space as usdf-elasticsearch (this could be done by creating secret and pulling from somewhere but works for now)

I then have then created the Index in Elasticsearch at "rucio_events"

And this PR completes the Rucio to Elasticsearch chain to then allow Rucio to generate logs for elasticsearch consumption and allow Hermes to submit the messages to Elasticsearch

I have also increased the Hermes count to 1, but if that causes problems with the Kafka Hermes do let me know

I then generated the helm file using make rucio-daemons.