### PR TITLE
Reapply / apply 3.4 daemons for hermes

### DIFF
--- a/overlays/prod/rucio/helm-rucio-daemons.yaml
+++ b/overlays/prod/rucio/helm-rucio-daemons.yaml
@@ -262,11 +262,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: usdf-rucio-edit
-  namespace: default
+  namespace: rucio
 subjects:
 - kind: ServiceAccount
   name: usdf-rucio-edit
-  namespace: default
+  namespace: rucio
 roleRef:
   kind: ClusterRole
   name: edit
@@ -1075,7 +1075,7 @@ spec:
             secretName: usdf-policy-package
       containers:
         - name: rucio-daemons
-          image: "rucio/rucio-daemons:release-33.5.0"
+          image: "rucio/rucio-daemons:release-34.0.0"
           imagePullPolicy: Always
           volumeMounts:
 


### PR DESCRIPTION
I didn't rebase before the merge so there seems to have been a not up to date hermes section created
The other change is the namespace of the RBAC and ServiceAccount
that seemed to have been changed in the last update to 3.4 but the make file created this like this
Can be edited to the current 'default' if I am wrong