### PR TITLE
Reenable HermesK and Kafka support. Needs both to work.

### DIFF
--- a/overlays/prod/rucio/kustomization.yaml
+++ b/overlays/prod/rucio/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 patchesStrategicMerge:
 - patch-ingress.yaml
 - grid-certificates-patch.yaml
-#- hermesk-image-patch.yaml
+- hermesk-image-patch.yaml
 
 secretGenerator:
 # rucio

--- a/overlays/prod/rucio/values-rucio-daemons.yaml
+++ b/overlays/prod/rucio/values-rucio-daemons.yaml
@@ -750,7 +750,7 @@ config:
   # email_test: ""
 
   hermes:
-    services_list: elastic
+    services_list: kafka, elastic
     elastic_endpoint: "http://elasticsearch-eck-elasticsearch-es-worker.elastic-system.svc.cluster.local:9200/rucio_events/_bulk"
 
   messaging-hermes-kafka:


### PR DESCRIPTION
This is a fix for the issues we had the other day concerning hermes being unable to find the Kafka support. Reenable HermesK as its actively being worked on.