### PR TITLE
Add Kafka-specific configuration.

### DIFF
--- a/overlays/dev/rucio/values-rucio-server.yaml
+++ b/overlays/dev/rucio/values-rucio-server.yaml
@@ -85,6 +85,9 @@ automaticRestart:
 secretMounts:
 - secretName: policy-package
   mountPath: /opt/rucio/permissions/rubin
+- secretName: hermeskafka-constants
+  mountPath: /usr/local/lib/python3.9/site-packages/rucio/common/constants.py
+  subPath: constants.py
 
 additionalEnvs:
 - name: PYTHONPATH
@@ -183,7 +186,8 @@ config:
   # username: ""
   ## config.trace.password: password for the topic (if necessary)
   # password: ""
-
+  hermes:
+    services_list: kafka
   policy:
     package: rubin
     ## config.permission.policy: (default "generic")


### PR DESCRIPTION
Add Kakfa as a messaging mechanism to constants.py. Replace activemq in services_list in rucio.cfg.