### PR TITLE
add logstash for dev and prod environments

### DIFF
--- a/overlays/dev/elastic/logstash/Makefile
+++ b/overlays/dev/elastic/logstash/Makefile
@@ -1,0 +1,26 @@
+LOGSTASH_VERSION := 0.10.0
+
+helm:
+	# helm repo add elastic https://helm.elastic.co
+	# helm repo update elastic
+
+
+logstash-deployment:
+	helm template logstash elastic/eck-logstash --version=${LOGSTASH_VERSION} --values=logstash/values-logstash.yaml > logstash/helm-logstash.yaml
+
+logstash: helm logstash-deployment
+
+run-dump: 
+	kubectl kustomize .
+
+dump:  logstash run-dump
+
+run-apply:  
+	kubectl apply -k .
+
+apply:  logstash run-apply
+
+run-destroy:
+	kubectl delete -k .
+
+destroy:  logstash run-destroy

--- a/overlays/dev/elastic/logstash/README.md
+++ b/overlays/dev/elastic/logstash/README.md
@@ -1,0 +1,5 @@
+# Rucio Database based monitoring
+
+Uses logstash to make queries from the Rucio database and send the results to Elastic/OpenSearch
+
+Initial pipelines were developed by Wenlong Yuham

--- a/overlays/dev/elastic/logstash/helm-logstash.yaml
+++ b/overlays/dev/elastic/logstash/helm-logstash.yaml
@@ -1,0 +1,93 @@
+# Source: eck-logstash/templates/logstash.yaml
+apiVersion: logstash.k8s.elastic.co/v1alpha1
+kind: Logstash
+metadata:
+  name: logstash-eck-logstash
+  labels:
+    helm.sh/chart: eck-logstash-0.10.0
+    app.kubernetes.io/name: eck-logstash
+    app.kubernetes.io/instance: logstash
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    eck.k8s.elastic.co/license: basic
+spec:
+  version: 8.15.0-SNAPSHOT
+  count: 1
+  image: opensearchproject/logstash-oss-with-opensearch-output-plugin:8.9.0
+  config:
+    log.level: info
+    pipeline.workers: 2
+  pipelinesRef:
+    secretName: rucio-pipelines
+  podTemplate:
+    spec:
+      containers:
+      - env:
+        - name: LS_HEAP_SIZE
+          value: 3g
+        - name: LS_JAVA_OPTS
+          value: -Xmx3g -Xms3g
+        - name: DB_SECRET_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: USERNAME
+              name: db-secrets
+        - name: DB_SECRET_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: PASSWORD
+              name: db-secrets
+        - name: DB_SECRET_CONNECT
+          valueFrom:
+            secretKeyRef:
+              key: CONNECT
+              name: db-secrets
+        - name: ES_SECRET_HOST
+          valueFrom:
+            secretKeyRef:
+              key: HOSTS
+              name: es-secrets
+        - name: ES_SECRET_USER
+          valueFrom:
+            secretKeyRef:
+              key: USER
+              name: es-secrets
+        - name: ES_SECRET_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: PASSWORD
+              name: es-secrets
+        name: logstash
+        resources:
+          limits:
+            cpu: 5
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 8Gi
+        volumeMounts:
+        - mountPath: /usr/share/logstash/jars
+          name: workdir
+      initContainers:
+      - args:
+        - -c
+        - curl -o /data/postgresql.jar -L https://jdbc.postgresql.org/download/postgresql-42.7.3.jar
+        command:
+        - /bin/sh
+        name: download-postgres
+        volumeMounts:
+        - mountPath: /data
+          name: workdir
+
+  volumeClaimTemplates:
+  - metadata:
+      name: workdir
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Mi
+  elasticsearchRefs: []
+  services: []
+  secureSettings: []

--- a/overlays/dev/elastic/logstash/kustomization.yaml
+++ b/overlays/dev/elastic/logstash/kustomization.yaml
@@ -1,0 +1,12 @@
+namespace: elastic-system
+
+resources:
+- helm-logstash.yaml
+
+patchesStrategicMerge: []
+
+secretGenerator:
+- name: rucio-pipelines
+  files:
+  - pipelines/pipelines.yml
+

--- a/overlays/dev/elastic/logstash/pipelines/pipelines.yml
+++ b/overlays/dev/elastic/logstash/pipelines/pipelines.yml
@@ -1,0 +1,124 @@
+# Accounts run once an hour 
+- pipeline.id: accounts
+  config.string: |
+    input {
+      jdbc {
+        jdbc_connection_string => "${DB_SECRET_CONNECT}"
+        jdbc_driver_library => "/usr/share/logstash/jars/postgresql.jar"
+        jdbc_driver_class => "org.postgresql.Driver"
+        schedule => "0 * * * *"
+        statement => "SELECT rses.rse, account_usage.account, account_usage.files, account_usage.bytes FROM account_usage INNER JOIN accounts ON account_usage.account=accounts.account INNER JOIN rses ON account_usage.rse_id=rses.id;"
+        last_run_metadata_path => "/tmp/.logstash__last_run"
+      }
+    }
+    output {
+      opensearch {
+          hosts => [ "https://usdf-opensearch.slac.stanford.edu/" ]
+          action => "index"
+          index => "rucio_accounts"
+          user => "${ES_SECRET_USER}"
+          password => "${ES_SECRET_PASSWORD}"
+          ssl => true
+          ssl_certificate_verification => false
+      }
+    }
+# Dids run once a day just after midnight as this is a large query - and draws down a lot of data
+- pipeline.id: dids
+  config.string: |
+    input {
+      jdbc {
+        jdbc_connection_string => "${DB_SECRET_CONNECT}"
+        jdbc_driver_library => "/usr/share/logstash/jars/postgresql.jar"
+        jdbc_driver_class => "org.postgresql.Driver"
+        schedule => "32 23 * * *"
+        statement => "SELECT scope, name, account, did_type, is_open, complete, availability, bytes, length, expired_at, deleted_at, events, guid, project, datatype, updated_at, created_at FROM dids;"
+        last_run_metadata_path => "/tmp/.logstash__last_run"
+      }
+    }
+    output {
+      opensearch {
+          hosts => [ "https://usdf-opensearch.slac.stanford.edu/" ]
+          action => "index"
+          index => "rucio_dids"
+          user => "${ES_SECRET_USER}"
+          password => "${ES_SECRET_PASSWORD}"
+          ssl => true
+          ssl_certificate_verification => false
+      }
+    }
+# Distances are something that does not change very often so run once a month
+- pipeline.id: distances
+  config.string: |
+    input {
+      jdbc {
+        jdbc_connection_string => "${DB_SECRET_CONNECT}"
+        jdbc_driver_library => "/usr/share/logstash/jars/postgresql.jar"
+        jdbc_driver_class => "org.postgresql.Driver"
+        schedule => "15 0 1 * *"
+        statement => "SELECT src_rse_id, dest_rse_id, distance  FROM distances;"
+        last_run_metadata_path => "/tmp/.logstash__last_run"
+      }
+    }
+    output {
+      opensearch {
+        hosts => [ "https://usdf-opensearch.slac.stanford.edu/" ]
+        action => "index"
+        index => "rucio_distances"
+        user => "${ES_SECRET_USER}"
+        password => "${ES_SECRET_PASSWORD}"
+        ssl => true
+        ssl_certificate_verification => false
+      }
+    }
+# Replicas run once an hour
+- pipeline.id: replicas
+  config.string: |
+    input {
+      jdbc {
+        jdbc_connection_string => "${DB_SECRET_CONNECT}"
+        jdbc_driver_library => "/usr/share/logstash/jars/postgresql.jar"
+        jdbc_driver_class => "org.postgresql.Driver"
+        schedule => "15 * * * *"
+        statement => "SELECT rses.rse, rses.country_name, rses.longitude, rses.latitude, replicas.scope, replicas.name, replicas.bytes, replicas.accessed_at, replicas.updated_at, replicas.created_at FROM replicas INNER JOIN rses ON  replicas.rse_id=rses.id WHERE replicas.state='A';"
+        last_run_metadata_path => "/tmp/.logstash__last_run"
+      }
+    }
+    output {
+      opensearch {
+        hosts => [ "https://usdf-opensearch.slac.stanford.edu/" ]
+        action => "index"
+        index => "rucio_replicas"
+        user => "${ES_SECRET_USER}"
+        password => "${ES_SECRET_PASSWORD}"
+        ssl => true
+        ssl_certificate_verification => false
+      }
+    }
+# Rses run once a hour
+- pipeline.id: rses
+  config.string: |
+    input {
+      jdbc {
+        jdbc_connection_string => "${DB_SECRET_CONNECT}"
+        jdbc_driver_library => "/usr/share/logstash/jars/postgresql.jar"
+        jdbc_driver_class => "org.postgresql.Driver"
+        schedule => "25 * * * *"
+        statement => "SELECT rses.rse, rses.country_name, rses.latitude, rses.longitude,rse_usage.source, rse_usage.used, rse_usage.free, rse_usage.files FROM rse_usage INNER JOIN rses ON rse_usage.rse_id=rses.id;"
+        last_run_metadata_path => "/tmp/.logstash__last_run"
+      }
+    }
+    output {
+      opensearch {
+        hosts => [ "https://usdf-opensearch.slac.stanford.edu/" ]
+        action => "index"
+        index => "rucio_rses"
+        user => "${ES_SECRET_USER}"
+        password => "${ES_SECRET_PASSWORD}"
+        ssl => true
+        ssl_certificate_verification => false
+      }
+    }
+
+
+
+

--- a/overlays/dev/elastic/logstash/values-logstash.yaml
+++ b/overlays/dev/elastic/logstash/values-logstash.yaml
@@ -1,0 +1,163 @@
+# Default values for eck-logstash.
+# This is a YAML-formatted file.
+
+# Overridable names of the Logstash resource.
+# By default, this is the Release name set for the chart,
+# followed by 'eck-logstash'.
+#
+# nameOverride will override the name of the Chart with the name set here,
+# so nameOverride: quickstart, would convert to '{{ Release.name }}-quickstart'
+#
+# nameOverride: "quickstart"
+#
+# fullnameOverride will override both the release name, and the chart name,
+# and will name the Logstash resource exactly as specified.
+#
+# fullnameOverride: "quickstart"
+
+# Version of Logstash.
+#
+version: 8.15.0-SNAPSHOT
+
+# Logstash Docker image to deploy
+#
+image: opensearchproject/logstash-oss-with-opensearch-output-plugin:8.9.0
+
+# Used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
+# Can only be used if ECK is enforcing RBAC on references.
+#
+# serviceAccountName: ""
+
+# Labels that will be applied to Logstash.
+#
+labels: {}
+
+# Annotations that will be applied to Logstash.
+#
+annotations: {}
+
+# Number of revisions to retain to allow rollback in the underlying StatefulSets.
+# By default, if not set, Kubernetes sets 10.
+#
+# revisionHistoryLimit: 2
+
+# Controlling the number of pods.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-scaling-logstash.html
+#
+count: 1
+
+# The logstash configuration, the ECK equivalent to logstash.yml
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-configuring-logstash
+#
+config:
+  pipeline.workers: 2
+  log.level: info
+
+# Set podTemplate to customize the pod used by Logstash
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-customize-pods.html
+#
+podTemplate:
+  spec:
+    initContainers:
+    - name: download-postgres
+      command: ["/bin/sh"]
+      args: ["-c", "curl -o /data/postgresql.jar -L https://jdbc.postgresql.org/download/postgresql-42.7.3.jar"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /data
+
+    containers:
+    - name: logstash
+      volumeMounts:
+      - name: workdir
+        mountPath: /usr/share/logstash/jars
+      resources:
+        requests:
+          cpu: 3
+          memory: 8Gi
+        limits:
+          cpu: 5
+          memory: 10Gi
+
+      env:
+      - name: LS_HEAP_SIZE
+        value: "3g"
+
+      - name: LS_JAVA_OPTS
+        value: "-Xmx3g -Xms3g"
+
+# Rucio DB connection url
+      - name: DB_SECRET_CONNECT
+        valueFrom:
+          secretKeyRef:
+            name: usdf-db-conn-str
+            key: db-conn-str
+
+# Elastic or opensearch username
+      - name: ES_SECRET_USER
+        value: rucio
+
+# Elastic or opensearch password
+      - name: ES_SECRET_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: usdf-rucio-elastic
+            key: PASSWORD
+
+#    volumes:
+#    - name: search-cert-authority
+#      secret:
+#        secretName: <search-cert-authority>
+#        mountPath:
+
+
+
+# Settings for configuring stack monitoring.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-stack-monitoring.html
+#
+monitoring: {}
+# metrics:
+#   elasticsearchRefs:
+#   - name: monitoring
+#     namespace: observability 
+# logs:
+#   elasticsearchRefs:
+#   - name: monitoring
+#     namespace: observability
+
+# The Logstash pipelines, the ECK equivalent to pipelines.yml
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-pipelines
+
+
+pipelinesRef:
+  secretName: 'rucio-pipelines'
+
+
+# volumeClaimTemplates
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-volume-claim-settings
+#
+volumeClaimTemplates:
+- metadata:
+    name: workdir
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 50Mi
+
+# ElasticsearchRefs are references to Elasticsearch clusters running in the same Kubernetes cluster.
+# Ensure that the 'clusterName' field matches what is referenced in the pipeline.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-pipelines-es
+#
+elasticsearchRefs: []
+#  - namespace: ''
+#    name: ''
+#    clusterName: ''
+#    serviceName: ''
+#    secretName: ''
+
+services: []
+
+# SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Logstash
+secureSettings: []

--- a/overlays/prod/logstash/Makefile
+++ b/overlays/prod/logstash/Makefile
@@ -1,0 +1,26 @@
+LOGSTASH_VERSION := 0.10.0
+
+helm:
+	# helm repo add elastic https://helm.elastic.co
+	# helm repo update elastic
+
+
+logstash-deployment:
+	helm template logstash elastic/eck-logstash --version=${LOGSTASH_VERSION} --values=logstash/values-logstash.yaml > logstash/helm-logstash.yaml
+
+logstash: helm logstash-deployment
+
+run-dump: 
+	kubectl kustomize .
+
+dump:  logstash run-dump
+
+run-apply:  
+	kubectl apply -k .
+
+apply:  logstash run-apply
+
+run-destroy:
+	kubectl delete -k .
+
+destroy:  logstash run-destroy

--- a/overlays/prod/logstash/README.md
+++ b/overlays/prod/logstash/README.md
@@ -1,0 +1,5 @@
+# Rucio Database based monitoring
+
+Uses logstash to make queries from the Rucio database and send the results to Elastic/OpenSearch
+
+Initial pipelines were developed by Wenlong Yuham

--- a/overlays/prod/logstash/helm-logstash.yaml
+++ b/overlays/prod/logstash/helm-logstash.yaml
@@ -1,0 +1,93 @@
+# Source: eck-logstash/templates/logstash.yaml
+apiVersion: logstash.k8s.elastic.co/v1alpha1
+kind: Logstash
+metadata:
+  name: logstash-eck-logstash
+  labels:
+    helm.sh/chart: eck-logstash-0.10.0
+    app.kubernetes.io/name: eck-logstash
+    app.kubernetes.io/instance: logstash
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    eck.k8s.elastic.co/license: basic
+spec:
+  version: 8.15.0-SNAPSHOT
+  count: 1
+  image: opensearchproject/logstash-oss-with-opensearch-output-plugin:8.9.0
+  config:
+    log.level: info
+    pipeline.workers: 2
+  pipelinesRef:
+    secretName: rucio-pipelines
+  podTemplate:
+    spec:
+      containers:
+      - env:
+        - name: LS_HEAP_SIZE
+          value: 3g
+        - name: LS_JAVA_OPTS
+          value: -Xmx3g -Xms3g
+        - name: DB_SECRET_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: USERNAME
+              name: db-secrets
+        - name: DB_SECRET_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: PASSWORD
+              name: db-secrets
+        - name: DB_SECRET_CONNECT
+          valueFrom:
+            secretKeyRef:
+              key: CONNECT
+              name: db-secrets
+        - name: ES_SECRET_HOST
+          valueFrom:
+            secretKeyRef:
+              key: HOSTS
+              name: es-secrets
+        - name: ES_SECRET_USER
+          valueFrom:
+            secretKeyRef:
+              key: USER
+              name: es-secrets
+        - name: ES_SECRET_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: PASSWORD
+              name: es-secrets
+        name: logstash
+        resources:
+          limits:
+            cpu: 5
+            memory: 10Gi
+          requests:
+            cpu: 3
+            memory: 8Gi
+        volumeMounts:
+        - mountPath: /usr/share/logstash/jars
+          name: workdir
+      initContainers:
+      - args:
+        - -c
+        - curl -o /data/postgresql.jar -L https://jdbc.postgresql.org/download/postgresql-42.7.3.jar
+        command:
+        - /bin/sh
+        name: download-postgres
+        volumeMounts:
+        - mountPath: /data
+          name: workdir
+
+  volumeClaimTemplates:
+  - metadata:
+      name: workdir
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Mi
+  elasticsearchRefs: []
+  services: []
+  secureSettings: []

--- a/overlays/prod/logstash/kustomization.yaml
+++ b/overlays/prod/logstash/kustomization.yaml
@@ -1,0 +1,12 @@
+namespace: elastic-system
+
+resources:
+- helm-logstash.yaml
+
+patchesStrategicMerge: []
+
+secretGenerator:
+- name: rucio-pipelines
+  files:
+  - pipelines/pipelines.yml
+

--- a/overlays/prod/logstash/pipelines/pipelines.yml
+++ b/overlays/prod/logstash/pipelines/pipelines.yml
@@ -1,0 +1,124 @@
+# Accounts run once an hour 
+- pipeline.id: accounts
+  config.string: |
+    input {
+      jdbc {
+        jdbc_connection_string => "${DB_SECRET_CONNECT}"
+        jdbc_driver_library => "/usr/share/logstash/jars/postgresql.jar"
+        jdbc_driver_class => "org.postgresql.Driver"
+        schedule => "0 * * * *"
+        statement => "SELECT rses.rse, account_usage.account, account_usage.files, account_usage.bytes FROM account_usage INNER JOIN accounts ON account_usage.account=accounts.account INNER JOIN rses ON account_usage.rse_id=rses.id;"
+        last_run_metadata_path => "/tmp/.logstash__last_run"
+      }
+    }
+    output {
+      opensearch {
+          hosts => [ "https://usdf-opensearch.slac.stanford.edu/" ]
+          action => "index"
+          index => "rucio_accounts"
+          user => "${ES_SECRET_USER}"
+          password => "${ES_SECRET_PASSWORD}"
+          ssl => true
+          ssl_certificate_verification => false
+      }
+    }
+# Dids run once a day just after midnight as this is a large query - and draws down a lot of data
+- pipeline.id: dids
+  config.string: |
+    input {
+      jdbc {
+        jdbc_connection_string => "${DB_SECRET_CONNECT}"
+        jdbc_driver_library => "/usr/share/logstash/jars/postgresql.jar"
+        jdbc_driver_class => "org.postgresql.Driver"
+        schedule => "32 23 * * *"
+        statement => "SELECT scope, name, account, did_type, is_open, complete, availability, bytes, length, expired_at, deleted_at, events, guid, project, datatype, updated_at, created_at FROM dids;"
+        last_run_metadata_path => "/tmp/.logstash__last_run"
+      }
+    }
+    output {
+      opensearch {
+          hosts => [ "https://usdf-opensearch.slac.stanford.edu/" ]
+          action => "index"
+          index => "rucio_dids"
+          user => "${ES_SECRET_USER}"
+          password => "${ES_SECRET_PASSWORD}"
+          ssl => true
+          ssl_certificate_verification => false
+      }
+    }
+# Distances are something that does not change very often so run once a month
+- pipeline.id: distances
+  config.string: |
+    input {
+      jdbc {
+        jdbc_connection_string => "${DB_SECRET_CONNECT}"
+        jdbc_driver_library => "/usr/share/logstash/jars/postgresql.jar"
+        jdbc_driver_class => "org.postgresql.Driver"
+        schedule => "15 0 1 * *"
+        statement => "SELECT src_rse_id, dest_rse_id, distance  FROM distances;"
+        last_run_metadata_path => "/tmp/.logstash__last_run"
+      }
+    }
+    output {
+      opensearch {
+        hosts => [ "https://usdf-opensearch.slac.stanford.edu/" ]
+        action => "index"
+        index => "rucio_distances"
+        user => "${ES_SECRET_USER}"
+        password => "${ES_SECRET_PASSWORD}"
+        ssl => true
+        ssl_certificate_verification => false
+      }
+    }
+# Replicas run once an hour
+- pipeline.id: replicas
+  config.string: |
+    input {
+      jdbc {
+        jdbc_connection_string => "${DB_SECRET_CONNECT}"
+        jdbc_driver_library => "/usr/share/logstash/jars/postgresql.jar"
+        jdbc_driver_class => "org.postgresql.Driver"
+        schedule => "15 * * * *"
+        statement => "SELECT rses.rse, rses.country_name, rses.longitude, rses.latitude, replicas.scope, replicas.name, replicas.bytes, replicas.accessed_at, replicas.updated_at, replicas.created_at FROM replicas INNER JOIN rses ON  replicas.rse_id=rses.id WHERE replicas.state='A';"
+        last_run_metadata_path => "/tmp/.logstash__last_run"
+      }
+    }
+    output {
+      opensearch {
+        hosts => [ "https://usdf-opensearch.slac.stanford.edu/" ]
+        action => "index"
+        index => "rucio_replicas"
+        user => "${ES_SECRET_USER}"
+        password => "${ES_SECRET_PASSWORD}"
+        ssl => true
+        ssl_certificate_verification => false
+      }
+    }
+# Rses run once a hour
+- pipeline.id: rses
+  config.string: |
+    input {
+      jdbc {
+        jdbc_connection_string => "${DB_SECRET_CONNECT}"
+        jdbc_driver_library => "/usr/share/logstash/jars/postgresql.jar"
+        jdbc_driver_class => "org.postgresql.Driver"
+        schedule => "25 * * * *"
+        statement => "SELECT rses.rse, rses.country_name, rses.latitude, rses.longitude,rse_usage.source, rse_usage.used, rse_usage.free, rse_usage.files FROM rse_usage INNER JOIN rses ON rse_usage.rse_id=rses.id;"
+        last_run_metadata_path => "/tmp/.logstash__last_run"
+      }
+    }
+    output {
+      opensearch {
+        hosts => [ "https://usdf-opensearch.slac.stanford.edu/" ]
+        action => "index"
+        index => "rucio_rses"
+        user => "${ES_SECRET_USER}"
+        password => "${ES_SECRET_PASSWORD}"
+        ssl => true
+        ssl_certificate_verification => false
+      }
+    }
+
+
+
+

--- a/overlays/prod/logstash/values-logstash.yaml
+++ b/overlays/prod/logstash/values-logstash.yaml
@@ -1,0 +1,163 @@
+# Default values for eck-logstash.
+# This is a YAML-formatted file.
+
+# Overridable names of the Logstash resource.
+# By default, this is the Release name set for the chart,
+# followed by 'eck-logstash'.
+#
+# nameOverride will override the name of the Chart with the name set here,
+# so nameOverride: quickstart, would convert to '{{ Release.name }}-quickstart'
+#
+# nameOverride: "quickstart"
+#
+# fullnameOverride will override both the release name, and the chart name,
+# and will name the Logstash resource exactly as specified.
+#
+# fullnameOverride: "quickstart"
+
+# Version of Logstash.
+#
+version: 8.15.0-SNAPSHOT
+
+# Logstash Docker image to deploy
+#
+image: opensearchproject/logstash-oss-with-opensearch-output-plugin:8.9.0
+
+# Used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
+# Can only be used if ECK is enforcing RBAC on references.
+#
+# serviceAccountName: ""
+
+# Labels that will be applied to Logstash.
+#
+labels: {}
+
+# Annotations that will be applied to Logstash.
+#
+annotations: {}
+
+# Number of revisions to retain to allow rollback in the underlying StatefulSets.
+# By default, if not set, Kubernetes sets 10.
+#
+# revisionHistoryLimit: 2
+
+# Controlling the number of pods.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-scaling-logstash.html
+#
+count: 1
+
+# The logstash configuration, the ECK equivalent to logstash.yml
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-configuring-logstash
+#
+config:
+  pipeline.workers: 2
+  log.level: info
+
+# Set podTemplate to customize the pod used by Logstash
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-customize-pods.html
+#
+podTemplate:
+  spec:
+    initContainers:
+    - name: download-postgres
+      command: ["/bin/sh"]
+      args: ["-c", "curl -o /data/postgresql.jar -L https://jdbc.postgresql.org/download/postgresql-42.7.3.jar"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /data
+
+    containers:
+    - name: logstash
+      volumeMounts:
+      - name: workdir
+        mountPath: /usr/share/logstash/jars
+      resources:
+        requests:
+          cpu: 3
+          memory: 8Gi
+        limits:
+          cpu: 5
+          memory: 10Gi
+
+      env:
+      - name: LS_HEAP_SIZE
+        value: "3g"
+
+      - name: LS_JAVA_OPTS
+        value: "-Xmx3g -Xms3g"
+
+# Rucio DB connection url
+      - name: DB_SECRET_CONNECT
+        valueFrom:
+          secretKeyRef:
+            name: usdf-db-conn-str
+            key: db-conn-str
+
+# Elastic or opensearch username
+      - name: ES_SECRET_USER
+        value: rucio
+
+# Elastic or opensearch password
+      - name: ES_SECRET_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: usdf-rucio-elastic
+            key: PASSWORD
+
+#    volumes:
+#    - name: search-cert-authority
+#      secret:
+#        secretName: <search-cert-authority>
+#        mountPath:
+
+
+
+# Settings for configuring stack monitoring.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-stack-monitoring.html
+#
+monitoring: {}
+# metrics:
+#   elasticsearchRefs:
+#   - name: monitoring
+#     namespace: observability 
+# logs:
+#   elasticsearchRefs:
+#   - name: monitoring
+#     namespace: observability
+
+# The Logstash pipelines, the ECK equivalent to pipelines.yml
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-pipelines
+
+
+pipelinesRef:
+  secretName: 'rucio-pipelines'
+
+
+# volumeClaimTemplates
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-volume-claim-settings
+#
+volumeClaimTemplates:
+- metadata:
+    name: workdir
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 50Mi
+
+# ElasticsearchRefs are references to Elasticsearch clusters running in the same Kubernetes cluster.
+# Ensure that the 'clusterName' field matches what is referenced in the pipeline.
+# ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash-configuration.html#k8s-logstash-pipelines-es
+#
+elasticsearchRefs: []
+#  - namespace: ''
+#    name: ''
+#    clusterName: ''
+#    serviceName: ''
+#    secretName: ''
+
+services: []
+
+# SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Logstash
+secureSettings: []


### PR DESCRIPTION
Add logstash with pipelines to enable user and RSE monitoring
This is in dev and prod, can be deployed immediately, but for actual monitoring I need to create the templates and indexes in opensearch, then get the indexes added to grafana (one index for each of the pipelines)