### PR TITLE
 Update automatix to run against the *_DATA_DISK 

### DIFF
--- a/overlays/prod/rucio/values-rucio-daemons.yaml
+++ b/overlays/prod/rucio/values-rucio-daemons.yaml
@@ -703,7 +703,7 @@ config:
     # support_rucio: "https://github.com/rucio/rucio/issues/"
 
   automatix:
-    rses: "FRDF_STS_DISK, IN2P3_BUTLER_DISK, LANCS_BUTLER_DISK, RAL_BUTLER_DISK, RAL_DATA_DISK, IN2P3_DATA_DISK, LANCS_DATA_DISK"
+    rses: "RAL_DATA_DISK, IN2P3_DATA_DISK, LANCS_DATA_DISK, SLAC_DATA_DISK"
     dataset_lifetime: 18000
     set_metadata: "True"
     account: "automatix"


### PR DESCRIPTION
We will only running automatix against the *_DATA_DISK in all the four facilities as the *_BUTLER_DISK  uses the same disk as the data. In addition, we try to avoid interfering with ingestd. 