### PR TITLE
Update CNPH to 1.25, migrate DB to Postgres 16.6

### DIFF
--- a/overlays/dev/Makefile
+++ b/overlays/dev/Makefile
@@ -7,13 +7,13 @@ helm:
 	helm repo update rucio
 
 rucio-server: helm
-	helm template usdf rucio/rucio-server --version=${SERVER_CHART_VERSION} --values=rucio/values-rucio-server.yaml > rucio/helm-rucio-server.yaml
+	helm template usdf rucio/rucio-server --namespace rucio --version=${SERVER_CHART_VERSION} --values=rucio/values-rucio-server.yaml > rucio/helm-rucio-server.yaml
 
 rucio-daemons: helm
-	helm template usdf rucio/rucio-daemons --version=${DAEMON_CHART_VERSION} --values=rucio/values-rucio-daemons.yaml > rucio/helm-rucio-daemons.yaml
+	helm template usdf rucio/rucio-daemons --namespace rucio --version=${DAEMON_CHART_VERSION} --values=rucio/values-rucio-daemons.yaml > rucio/helm-rucio-daemons.yaml
 
 rucio-ui: helm
-	helm template usdf rucio/rucio-webui --version=${UI_CHART_VERSION} --values=rucio/values-rucio-ui.yaml > rucio/helm-rucio-ui.yaml
+	helm template usdf rucio/rucio-webui --namespace rucio --version=${UI_CHART_VERSION} --values=rucio/values-rucio-ui.yaml > rucio/helm-rucio-ui.yaml
 
 rucio: rucio-server rucio-daemons rucio-ui
 
@@ -22,7 +22,7 @@ get-secrets:
 	vault kv get --field=usdf-server-hostkey secret/rubin/usdf-rucio-dev/rucio  > rucio/etc/.secrets/hostkey.pem
 	vault kv get --field=usdf-server-hostcert secret/rubin/usdf-rucio-dev/rucio  > rucio/etc/.secrets/hostcert.pem
 	vault kv get --field=usdf-server-cafile secret/rubin/usdf-rucio-dev/rucio  > rucio/etc/.secrets/ca.pem
-	vault kv get --field=usdf-db-16-conn-str secret/rubin/usdf-rucio-dev/rucio  > rucio/etc/.secrets/db-conn-str.txt
+	vault kv get --field=usdf-db-16b-conn-str secret/rubin/usdf-rucio-dev/rucio  > rucio/etc/.secrets/db-conn-str.txt
 	vault kv get --field=usdf-elasticsearch-password secret/rubin/usdf-rucio-dev/rucio  > rucio/etc/.secrets/usdf-elasticsearch-password
 	cp rucio/etc/automatix.json rucio/etc/.secrets/automatix.json
 	mkdir -p postgres/etc/.secrets
@@ -50,5 +50,3 @@ run-destroy:
 	kubectl delete -k .
 
 destroy: get-secrets rucio run-destroy clean-secrets 
-
-

--- a/overlays/dev/postgres/backup.yaml
+++ b/overlays/dev/postgres/backup.yaml
@@ -2,7 +2,7 @@ apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
   name: rucio-db-backup
-  namespace: rucio-db
+  namespace: rucio-db-16b
 spec:
   schedule: "0 0 0 * * *"
   backupOwnerReference: self

--- a/overlays/dev/postgres/cnpg-rucio-database.yaml
+++ b/overlays/dev/postgres/cnpg-rucio-database.yaml
@@ -1,8 +1,8 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: usdf-rucio-16
-  namespace: rucio-db
+  name: usdf-rucio-16b
+  namespace: rucio-db-16b
 spec:
   backup:
     retentionPolicy: "15d"
@@ -26,7 +26,7 @@ spec:
       secret:
         name: usdf-rucio-dev-creds
   
-  imageName:  ghcr.io/cloudnative-pg/postgresql:16.3
+  imageName:  ghcr.io/cloudnative-pg/postgresql:16.6
   inheritedMetadata:
     annotations:
       prometheus.io/scrape: 'true' 
@@ -73,5 +73,3 @@ spec:
   storage:
     storageClass: wekafs--sdf-k8s01
     size: 1000Gi
-
-

--- a/overlays/dev/postgres/cnpg-rucio-pooler.yaml
+++ b/overlays/dev/postgres/cnpg-rucio-pooler.yaml
@@ -2,14 +2,14 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Pooler
 metadata:
-  name: usdf-rucio-16-pooler-rw
-  namespace: rucio-db
+  name: usdf-rucio-16b-pooler-rw
+  namespace: rucio-db-16b
 spec:
   cluster:
     # the name here is not the cluster name, but the name of DB service that the pooler will control.
     # CNPG-operator automatcally added number to the name and starting from 1. It will not reuse 
     # the number if we redeploy a new DB. example of the name is usdf-rucio-1, usdf-rucio-2, ...
-    name: usdf-rucio-16
+    name: usdf-rucio-16b
   instances: 3
   type: rw
 
@@ -58,6 +58,4 @@ spec:
                 values:
                 - pooler
             topologyKey: "kubernetes.io/hostname"
-
-
 ---

--- a/overlays/dev/postgres/kustomization.yaml
+++ b/overlays/dev/postgres/kustomization.yaml
@@ -1,4 +1,4 @@
-namespace: rucio-db-16
+namespace: rucio-db-16b
 
 resources:
 - ns.yaml

--- a/overlays/dev/postgres/ns.yaml
+++ b/overlays/dev/postgres/ns.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: rucio-db
+  name: rucio-db-16b

--- a/overlays/prod/Makefile
+++ b/overlays/prod/Makefile
@@ -7,13 +7,13 @@ helm:
 	helm repo update rucio
 
 rucio-server: helm
-	helm template usdf rucio/rucio-server --version=${SERVER_CHART_VERSION} --values=rucio/values-rucio-server.yaml > rucio/helm-rucio-server.yaml
+	helm template usdf rucio/rucio-server --namespace rucio --version=${SERVER_CHART_VERSION} --values=rucio/values-rucio-server.yaml > rucio/helm-rucio-server.yaml
 
 rucio-daemons: helm
-	helm template usdf rucio/rucio-daemons --version=${DAEMON_CHART_VERSION} --values=rucio/values-rucio-daemons.yaml > rucio/helm-rucio-daemons.yaml
+	helm template usdf rucio/rucio-daemons --namespace rucio --version=${DAEMON_CHART_VERSION} --values=rucio/values-rucio-daemons.yaml > rucio/helm-rucio-daemons.yaml
 
 rucio-ui: helm
-	helm template usdf rucio/rucio-webui --version=${UI_CHART_VERSION} --values=rucio/values-rucio-ui.yaml > rucio/helm-rucio-ui.yaml
+	helm template usdf rucio/rucio-webui --namespace rucio --version=${UI_CHART_VERSION} --values=rucio/values-rucio-ui.yaml > rucio/helm-rucio-ui.yaml
 
 rucio: rucio-server rucio-daemons rucio-ui
 
@@ -32,7 +32,7 @@ get-secrets:
 	vault kv get --field=usdf-server-hostkey secret/rubin/usdf-rucio/rucio  > rucio/etc/.secrets/hostkey.pem
 	vault kv get --field=usdf-server-hostcert secret/rubin/usdf-rucio/rucio  > rucio/etc/.secrets/hostcert.pem
 	vault kv get --field=usdf-server-cafile secret/rubin/usdf-rucio/rucio  > rucio/etc/.secrets/ca.pem
-	vault kv get --field=usdf-db-conn-str secret/rubin/usdf-rucio/rucio  > rucio/etc/.secrets/db-conn-str.txt
+	vault kv get --field=usdf-db-16b-conn-str secret/rubin/usdf-rucio/rucio  > rucio/etc/.secrets/db-conn-str.txt
 	vault kv get --field=usdf-elasticsearch-password secret/rubin/usdf-rucio/rucio  > rucio/etc/.secrets/usdf-elasticsearch-password	
 	cp rucio/etc/automatix.json rucio/etc/.secrets/automatix.json
 	mkdir -p postgres/etc/.secrets

--- a/overlays/prod/postgres/backup.yaml
+++ b/overlays/prod/postgres/backup.yaml
@@ -2,7 +2,7 @@ apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
   name: rucio-db-backup
-  namespace: rucio-db
+  namespace: rucio-db-16b
 spec:
   schedule: "0 0 0 * * *"
   backupOwnerReference: self

--- a/overlays/prod/postgres/cnpg-rucio-database.yaml
+++ b/overlays/prod/postgres/cnpg-rucio-database.yaml
@@ -1,9 +1,8 @@
-
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   name: usdf-rucio
-  namespace: rucio-db
+  namespace: rucio-db-16b
 spec:
   backup:
     retentionPolicy: "15d"
@@ -27,7 +26,7 @@ spec:
       secret:
         name: usdf-rucio-creds
   
-  imageName:  ghcr.io/cloudnative-pg/postgresql:14.4-7
+  imageName:  ghcr.io/cloudnative-pg/postgresql:16.6
   inheritedMetadata:
     annotations:
       prometheus.io/scrape: 'true' 
@@ -61,5 +60,3 @@ spec:
   storage:
     storageClass: wekafs--sdf-k8s01
     size: 1000Gi
-
-

--- a/overlays/prod/postgres/cnpg-rucio-pooler.yaml
+++ b/overlays/prod/postgres/cnpg-rucio-pooler.yaml
@@ -3,14 +3,15 @@ apiVersion: postgresql.cnpg.io/v1
 kind: Pooler
 metadata:
   name: usdf-rucio-pooler-rw
-  namespace: rucio-db
+  namespace: rucio-db-16b
 spec:
   cluster:
     # the name here is not the cluster name, but the name of DB service that the pooler will control.
     # CNPG-operator automatcally added number to the name and starting from 1. It will not reuse 
     # the number if we redeploy a new DB. example of the name is usdf-rucio-1, usdf-rucio-2, ...
+    # Name here needs to match the name in metadata.name of cnpg-rucio-database.yaml
     name: usdf-rucio
-  instances: 3
+  instances: 6
   type: rw
 
   pgbouncer:
@@ -58,6 +59,4 @@ spec:
                 values:
                 - pooler
             topologyKey: "kubernetes.io/hostname"
-
-
 ---

--- a/overlays/prod/postgres/kustomization.yaml
+++ b/overlays/prod/postgres/kustomization.yaml
@@ -1,9 +1,10 @@
-namespace: rucio-db
+namespace: rucio-db-16b
 
 resources:
 - ns.yaml
 - cnpg-rucio-pooler.yaml
 - cnpg-rucio-database.yaml
+- backup.yaml
 
 secretGenerator:
 # database

--- a/overlays/prod/postgres/ns.yaml
+++ b/overlays/prod/postgres/ns.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: rucio-db
+  name: rucio-db-16b


### PR DESCRIPTION
Update CNPH to 1.25, migrate DB to Postgres 16.6 and fixed helm generation with explicit namespace.