### PR TITLE
dev: Reduce hermesk bulk 10000 to 1000, increase threads to 2

### DIFF
--- a/overlays/dev/rucio/values-rucio-daemons.yaml
+++ b/overlays/dev/rucio/values-rucio-daemons.yaml
@@ -348,9 +348,9 @@ darkReaper:
     value: "nullpool"
 
 hermes:
-  threads: 1
+  threads: 2
   podAnnotations: {}
-  bulk: 10000
+  bulk: 1000
   delay: 0
   brokerTimeout: 3
   resources:


### PR DESCRIPTION
Opensearch was returning HTTP 413, which was content too large. Reducing `bulk` from 10,000 to 1000 for hermesk. fixes this. `bulk: 1000` now matches the production configuration.

Threads was also increased to 2 to match production.